### PR TITLE
Feature: Add optional AMI override

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ module "azure_devops_agent" {
   # Instance Configuration 
   #--------------------------------------------------------------
   instance_type        = "t3.medium" # Must be x64 compatible
+  # ami_id             = "ami-0123456789abcdef0" # Optional: override the default Amazon Linux 2 AMI
   
   #--------------------------------------------------------------
   # Auto Scaling Group Configuration
@@ -202,6 +203,7 @@ When users are added to the docker group, they need to log out and back in for t
 | `azuredevops_url`          | Azure DevOps organization URL.                                                                                                         | `string`      | -           |   yes    |
 | `azuredevops_token`        | Azure DevOps PAT with Agent Pools (Read & manage) scope.                                                                               | `string`      | -           |   yes    |
 | `azuredevops_pool`         | Azure DevOps agent pool name.                                                                                                          | `string`      | -           |   yes    |
+| `ami_id`                   | Custom AMI ID for the agent instances. If not provided, the latest Amazon Linux 2 x64 AMI is used via SSM parameter lookup.            | `string`      | `null`      |    no    |
 | `instance_type`            | EC2 instance type (must be compatible with x64 architecture).                                                                          | `string`      | `"t3.small"`|    no    |
 | `ebs_volume_size`        | Size (GB) for the root EBS volume.                                                                                                     | `number`      | `32`        |    no    |
 | `ebs_volume_type`        | Type of EBS volume for the agent instances. Common types are 'gp2', 'gp3', 'io1', 'io2', 'st1', 'sc1'.                                | `string`      | `"gp3"`     |    no    |

--- a/_data.tf
+++ b/_data.tf
@@ -3,7 +3,8 @@ data "aws_caller_identity" "current" {}
 
 # Use the aws_ssm_parameter data source to get the latest AL2 AMI ID
 data "aws_ssm_parameter" "amazon_linux_2" {
-  name = var.al2_ami_ssm_parameter_name
+  count = var.ami_id == null ? 1 : 0
+  name  = var.al2_ami_ssm_parameter_name
 }
 
 data "aws_autoscaling_groups" "groups" {

--- a/asg_launch_template.tf
+++ b/asg_launch_template.tf
@@ -1,7 +1,7 @@
 resource "aws_launch_template" "agent_lt" {
   name_prefix   = "${var.name}-agent-lt-"
   description   = "Launch template for Azure DevOps agent instances in ${var.cluster_name}"
-  image_id      = coalesce(var.ami_id, data.aws_ssm_parameter.amazon_linux_2[0].value)
+  image_id      = coalesce(var.ami_id, try(data.aws_ssm_parameter.amazon_linux_2[0].value, null))
   instance_type = var.instance_type
 
   # Conditionally set the key_name based on the SSH access configuration

--- a/asg_launch_template.tf
+++ b/asg_launch_template.tf
@@ -1,7 +1,7 @@
 resource "aws_launch_template" "agent_lt" {
   name_prefix   = "${var.name}-agent-lt-"
   description   = "Launch template for Azure DevOps agent instances in ${var.cluster_name}"
-  image_id      = data.aws_ssm_parameter.amazon_linux_2.value
+  image_id      = coalesce(var.ami_id, data.aws_ssm_parameter.amazon_linux_2[0].value)
   instance_type = var.instance_type
 
   # Conditionally set the key_name based on the SSH access configuration

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "al2_ami_ssm_parameter_name" {
   default     = "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
 }
 
+variable "ami_id" {
+  description = "Specific AMI ID to use for agent instances. When set, the SSM parameter lookup for Amazon Linux 2 is skipped. Useful for organizations that maintain their own golden images."
+  type        = string
+  default     = null
+}
+
 variable "ebs_volume_size" {
   description = "Size in GB for the root EBS volume of the agent instances."
   type        = number


### PR DESCRIPTION
The module currently hardcodes AMI selection via an SSM parameter lookup that always resolves to the latest public Amazon Linux 2 AMI. This doesn't work in environments that require approved/golden AMIs.

This PR adds an optional `ami_id` variable that, when provided, skips the SSM lookup entirely and uses the specified AMI directly.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.